### PR TITLE
TYPO3 v13.4

### DIFF
--- a/Classes/Controller/TypoScriptObjectController.php
+++ b/Classes/Controller/TypoScriptObjectController.php
@@ -77,7 +77,9 @@ class TypoScriptObjectController extends AbstractPlugin
     protected function validateTemplatePath(array $templatePath): array
     {
         $contentType = '';
-        $typoScriptObject = $this->frontendController->tmpl->setup;
+        $typoScriptObject = $GLOBALS['TYPO3_REQUEST']
+            ->getAttribute('frontend.typoscript')
+            ->getSetupArray();
 
         $templatePaths = count($templatePath);
         for ($i = 0; $i < $templatePaths; $i++) {

--- a/Classes/Plugin/AbstractPlugin.php
+++ b/Classes/Plugin/AbstractPlugin.php
@@ -86,6 +86,20 @@ class AbstractPlugin
     public string $altLLkey = '';
 
     /**
+     * Pointer to the language to use.
+     *
+     * @var string
+     */
+    public ?string $LLtestPrefix;
+
+    /**
+     * Pointer to the language to use.
+     *
+     * @var string
+     */
+    public ?string $LLtestPrefixAlt;
+
+    /**
      * Should normally be set in the main function with the TypoScript content passed to the method.
      *
      * $conf[LOCAL_LANG][_key_] is reserved for Local Language overrides.
@@ -155,14 +169,16 @@ class AbstractPlugin
     public function pi_getLL(string $key, string $alternativeLabel = ''): ?string
     {
         $word = null;
-        if (!empty($this->LOCAL_LANG[$this->LLkey][$key][0]['target'])
+        if (
+            !empty($this->LOCAL_LANG[$this->LLkey][$key][0]['target'])
             || isset($this->LOCAL_LANG_UNSET[$this->LLkey][$key])
         ) {
             $word = $this->LOCAL_LANG[$this->LLkey][$key][0]['target'];
         } elseif ($this->altLLkey) {
             $alternativeLanguageKeys = GeneralUtility::trimExplode(',', $this->altLLkey, true);
             foreach ($alternativeLanguageKeys as $languageKey) {
-                if (!empty($this->LOCAL_LANG[$languageKey][$key][0]['target'])
+                if (
+                    !empty($this->LOCAL_LANG[$languageKey][$key][0]['target'])
                     || isset($this->LOCAL_LANG_UNSET[$languageKey][$key])
                 ) {
                     // Alternative language translation for key exists
@@ -172,7 +188,8 @@ class AbstractPlugin
             }
         }
         if ($word === null) {
-            if (!empty($this->LOCAL_LANG['default'][$key][0]['target'])
+            if (
+                !empty($this->LOCAL_LANG['default'][$key][0]['target'])
                 || isset($this->LOCAL_LANG_UNSET['default'][$key])
             ) {
                 // Get default translation (without charset conversion, english)

--- a/Classes/Plugin/AbstractPlugin.php
+++ b/Classes/Plugin/AbstractPlugin.php
@@ -110,13 +110,6 @@ class AbstractPlugin
     public $conf = [];
 
     /**
-     * Property for accessing TypoScriptFrontendController centrally
-     *
-     * @var TypoScriptFrontendController
-     */
-    protected TypoScriptFrontendController $frontendController;
-
-    /**
      * @var MarkerBasedTemplateService
      */
     protected MarkerBasedTemplateService $templateService;
@@ -128,11 +121,10 @@ class AbstractPlugin
      *
      * @param null $_ unused,
      */
-    public function __construct($_ = null, TypoScriptFrontendController $frontendController = null)
+    public function __construct($_ = null)
     {
-        $this->frontendController = $frontendController ?: $GLOBALS['TSFE'];
         $this->templateService = GeneralUtility::makeInstance(MarkerBasedTemplateService::class);
-        $this->LLkey = $this->frontendController->getLanguage()->getTypo3Language();
+        $this->LLkey = $GLOBALS['TYPO3_REQUEST']->getAttribute('site')->getDefaultLanguage()->getTypo3Language();
 
         $locales = GeneralUtility::makeInstance(Locales::class);
         if ($locales->isValidLanguageKey($this->LLkey)) {

--- a/composer.json
+++ b/composer.json
@@ -27,16 +27,16 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": "^8.1",
-		"typo3/cms-backend": "^12.4",
-		"typo3/cms-core": "^12.4",
-		"typo3/cms-frontend": "^12.4"
+		"typo3/cms-backend": "^13.4",
+		"typo3/cms-core": "^13.4",
+		"typo3/cms-frontend": "^13.4"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.75",
 		"squizlabs/php_codesniffer": "^3.13",
 		"ssch/typo3-rector": "^2.13",
-		"typo3/cms-fluid-styled-content": "^12.4",
-		"typo3/cms-tstemplate": "^12.4",
+		"typo3/cms-fluid-styled-content": "^13.4",
+		"typo3/cms-tstemplate": "^13.4",
 		"typo3/tailor": "^1.7"
 	},
 	"autoload": {


### PR DESCRIPTION
# Pull Request

## Related Issues

* Closes #75 

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on TYPO3 dev-main
* [ ] Changes have been tested on PHP 8.1.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

A little PR to start off the support for TYPO3 v13. It is not great to access `TYPO3_REQUEST` as a global, but this way at least the basic functionality is already restored. Due to this being a quick fix for us, I haven't went through the steps to test it thoroughly. It works as is on PHP 8.4.x with only two 'strong' deprecations (PLUGIN_TYPE_PLUGIN; addPageTSConfig).

Feel free to pick up from here for a general release.
